### PR TITLE
Fix Codex usage percent parsing

### DIFF
--- a/test_all_providers.js
+++ b/test_all_providers.js
@@ -35,14 +35,44 @@ const testCases = [
         data: {
             "used_percent": 45.5,
             "limit_window_seconds": 3600
-        }
+        },
+        expectedUsedPercent: 45.5
+    },
+    {
+        name: "Codex rate_limit windows (1% used)",
+        data: {
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 1,
+                    "limit_window_seconds": 18000,
+                    "reset_after_seconds": 7200
+                },
+                "secondary_window": {
+                    "used_percent": 12,
+                    "limit_window_seconds": 604800,
+                    "reset_after_seconds": 432000
+                }
+            }
+        },
+        expectedUsedPercent: 1
+    },
+    {
+        name: "Codex remaining_percent",
+        data: {
+            "primary": {
+                "remaining_percent": 99,
+                "limit_window_seconds": 18000
+            }
+        },
+        expectedUsedPercent: 1
     },
     {
         name: "Generic CLI (remaining/total)",
         data: {
             "remaining": 5,
             "total": 20
-        }
+        },
+        expectedUsedPercent: 75
     }
 ];
 
@@ -57,6 +87,11 @@ testCases.forEach(test => {
         if (primary) {
             console.log(`  ✓ Success: ${primary.usedPercent.toFixed(2)}% used`);
             if (primary.resetDescription) console.log(`  └─ Reset: ${primary.resetDescription}`);
+
+            if (test.expectedUsedPercent !== undefined &&
+                Math.abs(primary.usedPercent - test.expectedUsedPercent) > 0.0001) {
+                throw new Error(`Expected ${test.expectedUsedPercent}% used, got ${primary.usedPercent}%`);
+            }
         } else {
             console.log("  ✗ Failed: No primary window found");
         }

--- a/usageApi.js
+++ b/usageApi.js
@@ -27,6 +27,82 @@ export class UsageApiError extends Error {
  * Client for fetching and parsing usage data from OpenAI/ChatGPT.
  * Cliente para obtener y parsear datos de uso de OpenAI/ChatGPT.
  */
+const normalizePercentValue = (rawPercent, mode = 'used') => {
+    let percent = parseFloat(rawPercent);
+    if (isNaN(percent)) return null;
+    percent = percent / 100;
+    if (mode === 'remaining') percent = 1 - percent;
+    return Math.min(1, Math.max(0, percent));
+};
+
+const makeWindow = (obj) => {
+    if (!obj || typeof obj !== 'object') return null;
+
+    const rawUsedPercent = obj.used_percent ?? obj.usedPercent;
+    if (rawUsedPercent !== undefined) {
+        const percent = normalizePercentValue(rawUsedPercent, 'used');
+        if (percent !== null) {
+            return {
+                used: percent,
+                limit: 1,
+                percent,
+                window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
+                reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
+            };
+        }
+    }
+
+    const rawRemainingPercent =
+        obj.remaining_percent ?? obj.remainingPercent ?? obj.percent_remaining ?? obj.percentRemaining;
+    if (rawRemainingPercent !== undefined) {
+        const percent = normalizePercentValue(rawRemainingPercent, 'remaining');
+        if (percent !== null) {
+            return {
+                used: percent,
+                limit: 1,
+                percent,
+                window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
+                reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
+            };
+        }
+    }
+
+    let usedValue = obj.used ?? obj.usage ?? obj.count ?? obj.current_usage ?? obj.totalUsage ?? obj.keyUsage;
+    let limitValue = obj.limit ?? obj.cap ?? obj.max ?? obj.usage_limit ?? obj.total ?? obj.totalCredits;
+    
+    if (usedValue === undefined && obj.remaining !== undefined && limitValue !== undefined) {
+        usedValue = parseFloat(limitValue) - parseFloat(obj.remaining);
+    }
+
+    if (usedValue !== undefined && limitValue !== undefined) {
+        const used = parseFloat(usedValue);
+        const limit = parseFloat(limitValue);
+        
+        if (!isNaN(used) && !isNaN(limit) && limit > 0) {
+            return {
+                used,
+                limit,
+                percent: Math.min(1, Math.max(0, used / limit)),
+                window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
+                reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
+            };
+        }
+    }
+
+    return null;
+};
+
+const addWindow = (target, win) => {
+    if (win) target.push(win);
+};
+
+const dedupe = (items) => items.filter((w, index, self) =>
+    index === self.findIndex((t) => (
+        t.window_seconds === w.window_seconds &&
+        Math.abs(t.percent - w.percent) < 0.0001
+    ))
+);
+
 export class UsageApiClient {
     constructor() {
         this._session = new Soup.Session({
@@ -171,34 +247,13 @@ export class UsageApiClient {
         };
 
         const mapSingle = (obj) => {
-            if (!obj || typeof obj !== 'object') return null;
-            
-            let usedPercent = obj.usedPercent;
-            let resetSecs = obj.reset_after_seconds ?? obj.reset_after ?? obj.reset_in_seconds ?? obj.reset_time;
-            
-            // Try to extract if usedPercent is missing
-            if (usedPercent === undefined) {
-                let used = obj.used ?? obj.usage ?? obj.count ?? obj.current_usage ?? obj.totalUsage ?? obj.keyUsage;
-                let limit = obj.limit ?? obj.cap ?? obj.max ?? obj.usage_limit ?? obj.total ?? obj.totalCredits;
-                
-                if (used === undefined && obj.remaining !== undefined && limit !== undefined) {
-                    used = parseFloat(limit) - parseFloat(obj.remaining);
-                }
-                
-                if (used !== undefined && limit !== undefined && limit > 0) {
-                    usedPercent = (parseFloat(used) / parseFloat(limit)) * 100;
-                } else if (obj.used_percent !== undefined || obj.usedPercent !== undefined) {
-                    usedPercent = parseFloat(obj.used_percent ?? obj.usedPercent);
-                    if (usedPercent <= 1.0) usedPercent *= 100;
-                }
-            }
-
-            if (usedPercent === undefined) return null;
+            const win = makeWindow(obj);
+            if (!win) return null;
 
             return {
-                usedPercent: usedPercent,
-                resetDescription: formatReset(resetSecs) || obj.resetDescription || '',
-                windowSeconds: obj.window_seconds || (obj.windowMinutes ? obj.windowMinutes * 60 : 0)
+                usedPercent: win.percent * 100,
+                resetDescription: formatReset(win.reset_after_seconds) || obj.resetDescription || '',
+                windowSeconds: win.window_seconds
             };
         };
 
@@ -249,75 +304,6 @@ export class UsageApiClient {
         const seen = new Set();
         const canonicalWindows = [];
 
-        const normalizePercentValue = (rawPercent, mode = 'used') => {
-            let percent = parseFloat(rawPercent);
-            if (isNaN(percent)) return null;
-            percent = percent / 100;
-            if (mode === 'remaining') percent = 1 - percent;
-            return Math.min(1, Math.max(0, percent));
-        };
-
-        const makeWindow = (obj) => {
-            if (!obj || typeof obj !== 'object') return null;
-
-            const rawUsedPercent = obj.used_percent ?? obj.usedPercent;
-            if (rawUsedPercent !== undefined) {
-                const percent = normalizePercentValue(rawUsedPercent, 'used');
-                if (percent !== null) {
-                    return {
-                        used: percent,
-                        limit: 1,
-                        percent,
-                        window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
-                        reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
-                    };
-                }
-            }
-
-            const rawRemainingPercent =
-                obj.remaining_percent ?? obj.remainingPercent ?? obj.percent_remaining ?? obj.percentRemaining;
-            if (rawRemainingPercent !== undefined) {
-                const percent = normalizePercentValue(rawRemainingPercent, 'remaining');
-                if (percent !== null) {
-                    return {
-                        used: percent,
-                        limit: 1,
-                        percent,
-                        window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
-                        reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
-                    };
-                }
-            }
-
-            let usedValue = obj.used ?? obj.usage ?? obj.count ?? obj.current_usage ?? obj.totalUsage ?? obj.keyUsage;
-            let limitValue = obj.limit ?? obj.cap ?? obj.max ?? obj.usage_limit ?? obj.total ?? obj.totalCredits;
-            
-            if (usedValue === undefined && obj.remaining !== undefined && limitValue !== undefined) {
-                usedValue = parseFloat(limitValue) - parseFloat(obj.remaining);
-            }
-
-            if (usedValue !== undefined && limitValue !== undefined) {
-                const used = parseFloat(usedValue);
-                const limit = parseFloat(limitValue);
-                
-                if (!isNaN(used) && !isNaN(limit) && limit > 0) {
-                    return {
-                        used,
-                        limit,
-                        percent: Math.min(1, Math.max(0, used / limit)),
-                        window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
-                        reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
-                    };
-                }
-            }
-
-            return null;
-        };
-
-        const addWindow = (target, win) => {
-            if (win) target.push(win);
-        };
-
         const rateLimit = payload?.rate_limit || payload?.usage?.rate_limit;
         if (rateLimit) {
             [
@@ -334,13 +320,6 @@ export class UsageApiClient {
 
         ['primary', 'secondary', 'tertiary', 'quaternary'].forEach((key) =>
             addWindow(canonicalWindows, makeWindow(payload?.[key] || payload?.usage?.[key]))
-        );
-
-        const dedupe = (items) => items.filter((w, index, self) =>
-            index === self.findIndex((t) => (
-                t.window_seconds === w.window_seconds &&
-                Math.abs(t.percent - w.percent) < 0.0001
-            ))
         );
 
         if (canonicalWindows.length > 0) {

--- a/usageApi.js
+++ b/usageApi.js
@@ -247,37 +247,51 @@ export class UsageApiClient {
     extractWindows(payload) {
         const windows = [];
         const seen = new Set();
+        const canonicalWindows = [];
 
-        const collect = (obj) => {
-            if (!obj || typeof obj !== 'object' || seen.has(obj)) return;
-            seen.add(obj);
-            
-            // Support for used_percent / usedPercent directly
-            // Soporte para used_percent / usedPercent directamente
-            const rawPercent = obj.used_percent ?? obj.usedPercent;
-            if (rawPercent !== undefined) {
-                let percent = parseFloat(rawPercent);
-                if (!isNaN(percent)) {
-                    // If > 1, assume it's 0-100 scale
-                    if (percent > 1.0) percent = percent / 100;
+        const normalizePercentValue = (rawPercent, mode = 'used') => {
+            let percent = parseFloat(rawPercent);
+            if (isNaN(percent)) return null;
+            percent = percent / 100;
+            if (mode === 'remaining') percent = 1 - percent;
+            return Math.min(1, Math.max(0, percent));
+        };
 
-                    windows.push({
+        const makeWindow = (obj) => {
+            if (!obj || typeof obj !== 'object') return null;
+
+            const rawUsedPercent = obj.used_percent ?? obj.usedPercent;
+            if (rawUsedPercent !== undefined) {
+                const percent = normalizePercentValue(rawUsedPercent, 'used');
+                if (percent !== null) {
+                    return {
                         used: percent,
                         limit: 1,
-                        percent: percent,
+                        percent,
                         window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
                         reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
-                    });
+                    };
                 }
             }
 
-            // Look for usage/limit pairs
-            // Buscar pares de uso/límite
+            const rawRemainingPercent =
+                obj.remaining_percent ?? obj.remainingPercent ?? obj.percent_remaining ?? obj.percentRemaining;
+            if (rawRemainingPercent !== undefined) {
+                const percent = normalizePercentValue(rawRemainingPercent, 'remaining');
+                if (percent !== null) {
+                    return {
+                        used: percent,
+                        limit: 1,
+                        percent,
+                        window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
+                        reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
+                    };
+                }
+            }
+
             let usedValue = obj.used ?? obj.usage ?? obj.count ?? obj.current_usage ?? obj.totalUsage ?? obj.keyUsage;
             let limitValue = obj.limit ?? obj.cap ?? obj.max ?? obj.usage_limit ?? obj.total ?? obj.totalCredits;
             
-            // Handle 'remaining' + 'total' case
-            // Manejar caso de 'restante' + 'total'
             if (usedValue === undefined && obj.remaining !== undefined && limitValue !== undefined) {
                 usedValue = parseFloat(limitValue) - parseFloat(obj.remaining);
             }
@@ -287,15 +301,57 @@ export class UsageApiClient {
                 const limit = parseFloat(limitValue);
                 
                 if (!isNaN(used) && !isNaN(limit) && limit > 0) {
-                    windows.push({
-                        used: used,
-                        limit: limit,
-                        percent: used / limit,
-                        window_seconds: obj.window_seconds || obj.duration_seconds || 0,
+                    return {
+                        used,
+                        limit,
+                        percent: Math.min(1, Math.max(0, used / limit)),
+                        window_seconds: obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0,
                         reset_after_seconds: obj.reset_after_seconds || obj.reset_after || 0
-                    });
+                    };
                 }
             }
+
+            return null;
+        };
+
+        const addWindow = (target, win) => {
+            if (win) target.push(win);
+        };
+
+        const rateLimit = payload?.rate_limit || payload?.usage?.rate_limit;
+        if (rateLimit) {
+            [
+                'primary_window',
+                'secondary_window',
+                'tertiary_window',
+                'quaternary_window',
+                'primary',
+                'secondary',
+                'tertiary',
+                'quaternary',
+            ].forEach((key) => addWindow(canonicalWindows, makeWindow(rateLimit[key])));
+        }
+
+        ['primary', 'secondary', 'tertiary', 'quaternary'].forEach((key) =>
+            addWindow(canonicalWindows, makeWindow(payload?.[key] || payload?.usage?.[key]))
+        );
+
+        const dedupe = (items) => items.filter((w, index, self) =>
+            index === self.findIndex((t) => (
+                t.window_seconds === w.window_seconds &&
+                Math.abs(t.percent - w.percent) < 0.0001
+            ))
+        );
+
+        if (canonicalWindows.length > 0) {
+            return dedupe(canonicalWindows);
+        }
+
+        const collect = (obj) => {
+            if (!obj || typeof obj !== 'object' || seen.has(obj)) return;
+            seen.add(obj);
+
+            addWindow(windows, makeWindow(obj));
 
             // Recurse into all keys
             // Recorrer todas las claves
@@ -308,11 +364,6 @@ export class UsageApiClient {
         
         // De-duplicate windows
         // Eliminar ventanas duplicadas
-        return windows.filter((w, index, self) => 
-            index === self.findIndex((t) => (
-                t.window_seconds === w.window_seconds && 
-                Math.abs(t.percent - w.percent) < 0.0001
-            ))
-        );
+        return dedupe(windows);
     }
 }


### PR DESCRIPTION
## Summary

  Fix Codex usage parsing so ChatGPT quota values like `used_percent: 1` are treated as 1%
  used, not 100% used. This resolves the extension showing `0% left` when the web UI shows
  roughly `99% left`.

  ## Changes

  - Treat percent-named fields as 0-100 percentage values.
  - Prefer canonical Codex `rate_limit.*_window` entries before recursive fallback
  extraction.
  - Add support for `remaining_percent` / `percent_remaining` style fields.
  - Add regression coverage for Codex `used_percent: 1`, `remaining_percent: 99`, and
  existing fallback formats.
