### PR TITLE
fix: Codex shows only Spark windows — don't misdetect extraRateWindows as Antigravity

### DIFF
--- a/test_all_providers.js
+++ b/test_all_providers.js
@@ -2,6 +2,46 @@ import { formatResetDescription, UsageApiClient } from "./usageApi.js";
 
 const client = new UsageApiClient();
 
+// Real-world Codex payload shape: canonical primary/secondary windows plus
+// extraRateWindows for Codex Spark. The canonical windows must stay first and
+// the Spark windows must be appended, not replace them.
+const codexSparkUsage = {
+  accountEmail: "user@example.com",
+  updatedAt: "2026-07-10T13:08:58Z",
+  identity: { providerID: "codex" },
+  primary: {
+    usedPercent: 49,
+    windowMinutes: 300,
+    resetsAt: "2030-01-01T17:06:02Z",
+  },
+  secondary: {
+    usedPercent: 24,
+    windowMinutes: 10080,
+    resetsAt: "2030-01-01T06:17:16Z",
+  },
+  tertiary: null,
+  extraRateWindows: [
+    {
+      id: "codex-spark",
+      title: "Codex Spark 5-hour",
+      window: {
+        usedPercent: 5,
+        windowMinutes: 300,
+        resetsAt: "2030-01-01T18:08:57Z",
+      },
+    },
+    {
+      id: "codex-spark-weekly",
+      title: "Codex Spark Weekly",
+      window: {
+        usedPercent: 3,
+        windowMinutes: 10080,
+        resetsAt: "2030-01-01T13:08:57Z",
+      },
+    },
+  ],
+};
+
 const testCases = [
   {
     name: "OpenRouter (User reported)",
@@ -72,6 +112,11 @@ const testCases = [
       total: 20,
     },
     expectedUsedPercent: 75,
+  },
+  {
+    name: "Codex with Spark extra rate windows",
+    data: { provider: "codex", usage: codexSparkUsage },
+    expectedUsedPercent: 49,
   },
   {
     name: "Antigravity (User reported)",
@@ -212,4 +257,37 @@ if (laterWeeklyReset !== `Resets at ${laterDateTime} (in 48h)`) {
 
 console.log(
   "✓ Weekly reset dates are shown only when the reset is on another day",
+);
+
+// Codex + Spark: canonical windows stay in primary/secondary, Spark windows
+// fill tertiary/quaternary, and labels cover all four tiers in order.
+const codexSpark = client.normalizeSummary(codexSparkUsage, false);
+const sparkExpectations = [
+  ["primary", 49],
+  ["secondary", 24],
+  ["tertiary", 5],
+  ["quaternary", 3],
+];
+sparkExpectations.forEach(([tier, expected]) => {
+  const win = codexSpark.usage[tier];
+  if (!win || Math.abs(win.usedPercent - expected) > 0.0001) {
+    throw new Error(
+      `Codex Spark: expected ${tier} at ${expected}% used, got ${win ? win.usedPercent : "null"}`,
+    );
+  }
+});
+const expectedSparkLabels = [
+  "5-Hour Window",
+  "Weekly Window",
+  "Codex Spark 5-hour",
+  "Codex Spark Weekly",
+];
+if (JSON.stringify(codexSpark.labels) !== JSON.stringify(expectedSparkLabels)) {
+  throw new Error(
+    `Codex Spark: expected labels ${JSON.stringify(expectedSparkLabels)}, got ${JSON.stringify(codexSpark.labels)}`,
+  );
+}
+
+console.log(
+  "✓ Codex extraRateWindows are appended after canonical windows with labels",
 );

--- a/usageApi.js
+++ b/usageApi.js
@@ -191,12 +191,10 @@ export class UsageApiClient {
     normalizeSummary(payload, isAntigravity = false) {
         // Detect if the provider is antigravity
         // Detectar si el proveedor es antigravity
-        const isAnti = isAntigravity || 
-            payload?.identity?.providerID === "antigravity" || 
+        const isAnti = isAntigravity ||
+            payload?.identity?.providerID === "antigravity" ||
             payload?.provider === "antigravity" ||
-            payload?.usage?.identity?.providerID === "antigravity" ||
-            (payload?.extraRateWindows && Array.isArray(payload.extraRateWindows)) ||
-            (payload?.usage?.extraRateWindows && Array.isArray(payload.usage.extraRateWindows));
+            payload?.usage?.identity?.providerID === "antigravity";
 
         const mapSingle = (obj) => {
             const win = makeWindow(obj);
@@ -245,17 +243,48 @@ export class UsageApiClient {
             };
         }
 
-        // If it already has structured tiers, normalize them in place to keep order
+        // If it already has structured tiers, normalize them in place to keep order,
+        // then fill any remaining tier slots with extraRateWindows (e.g. Codex Spark)
+        // Si ya tiene niveles estructurados, normalizarlos manteniendo el orden,
+        // y rellenar los niveles restantes con extraRateWindows (ej. Codex Spark)
         if (payload.primary || payload.secondary || payload.tertiary) {
+            const labelForWindow = (win) => {
+                if (!win || !win.windowSeconds) return 'Usage Window';
+                const hours = Math.round(win.windowSeconds / 3600);
+                if (hours >= 24) {
+                    const days = Math.round(hours / 24);
+                    return days === 7 ? 'Weekly Window' : `${days}-Day Window`;
+                }
+                return `${hours}-Hour Window`;
+            };
+
+            const queue = [];
+            const tierKeys = ['primary', 'secondary', 'tertiary', 'quaternary'];
+            tierKeys.forEach((key) => {
+                const win = mapSingle(payload[key]);
+                if (win) queue.push({ win, label: labelForWindow(win) });
+            });
+            if (Array.isArray(extraWindows)) {
+                extraWindows.forEach((item) => {
+                    const win = mapSingle(item?.window);
+                    if (win) queue.push({ win, label: item?.title || labelForWindow(win) });
+                });
+            }
+
+            const mappedTiers = {};
+            const labels = [];
+            tierKeys.forEach((key, idx) => {
+                mappedTiers[key] = queue[idx] ? queue[idx].win : null;
+                if (queue[idx]) labels.push(queue[idx].label);
+            });
+
             return {
+                labels,
                 usage: {
                     ...payload,
                     accountEmail: payload?.accountEmail || payload?.email || 'API User',
                     updatedAt: payload?.updatedAt || new Date().toISOString(),
-                    primary: mapSingle(payload.primary),
-                    secondary: mapSingle(payload.secondary),
-                    tertiary: mapSingle(payload.tertiary),
-                    quaternary: mapSingle(payload.quaternary),
+                    ...mappedTiers,
                 }
             };
         }


### PR DESCRIPTION
## Problem

For the Codex provider, the panel shows **only the Codex Spark windows** and drops the real 5-hour and weekly GPT usage windows.

Cause: `normalizeSummary()` treats any payload containing an `extraRateWindows` array as Antigravity:

```js
const isAnti = isAntigravity ||
    ... ||
    (payload?.extraRateWindows && Array.isArray(payload.extraRateWindows)) ||
    (payload?.usage?.extraRateWindows && Array.isArray(payload.usage.extraRateWindows));
```

The Antigravity branch then builds the tier list **exclusively from `extraRateWindows`**, discarding `primary`/`secondary`. Since codexbar now reports Codex Spark limits via `extraRateWindows`, Codex payloads take this branch and only Spark is displayed.

## Fix

1. **Antigravity detection** now requires explicit identification (`provider`/`providerID` = `antigravity`, or the caller's flag) instead of inferring from the presence of `extraRateWindows`. The existing Antigravity path is unchanged — its payloads identify themselves via `identity.providerID`, and `extension.js` also passes `isAntigravity` based on the configured provider id.

2. **Structured-tiers path** now appends `extraRateWindows` entries after the canonical windows, filling the remaining of the four tier slots, and returns `labels` for all tiers (window duration for canonical ones, `title` for extras).

Codex with Spark now renders all four bars:

| Window | Usage |
|---|---|
| 5-Hour Window | 49% |
| Weekly Window | 24% |
| Codex Spark 5-hour | 5% |
| Codex Spark Weekly | 3% |

## Testing

- Added a regression case to `test_all_providers.js`: a real-world-shaped Codex payload with Spark `extraRateWindows`, asserting all four tiers and their labels.
- `gjs -m test_all_providers.js` passes, including the existing Antigravity case.
- Verified against live `codexbar usage --provider codex --source auto --format json` output on GNOME Shell 50.3 / Fedora.

