### PR TITLE
Show additional Codex usage details

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -153,6 +153,9 @@ export default class CodexBarExtension extends Extension {
       this._settings.connect("changed::show-logos", () => this._updateUI()),
     );
     this._signals.push(
+      this._settings.connect("changed::show-pacing-info", () => this._updateUI()),
+    );
+    this._signals.push(
       this._settings.connect("changed::first-run", () => this._updateUI()),
     );
     this._signals.push(
@@ -788,6 +791,7 @@ export default class CodexBarExtension extends Extension {
     }
 
     const usage = data.usage;
+    const showPacing = this._settings.get_boolean("show-pacing-info");
 
     // Account information
     // Información de la cuenta
@@ -920,7 +924,7 @@ export default class CodexBarExtension extends Extension {
 
         this._contentBox.add_child(statsBox);
 
-        if (entry.showPace && tierData.windowSeconds >= 7 * 24 * 3600) {
+        if (showPacing && entry.showPace && tierData.windowSeconds >= 7 * 24 * 3600) {
           const pace = calculateUsagePace(tierData);
           if (pace) {
             const roundedReserve = Math.round(pace.reservePercent);

--- a/extension.js
+++ b/extension.js
@@ -8,7 +8,7 @@ import {
 } from "resource:///org/gnome/shell/extensions/extension.js";
 import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
-import { UsageApiClient } from "./usageApi.js";
+import { calculateUsagePace, UsageApiClient } from "./usageApi.js";
 import { loadToken, nullTokenSchema } from "./secret.js";
 
 function logDev(msg) {
@@ -802,9 +802,26 @@ export default class CodexBarExtension extends Extension {
       );
       let accText = usage.accountEmail;
       if (usage.loginMethod) accText += ` (${usage.loginMethod})`;
-      accountBox.add_child(
+      const accountDetails = new St.BoxLayout({
+        vertical: false,
+        x_expand: true,
+      });
+      accountDetails.add_child(
         new St.Label({ text: accText, style_class: "codexbar-usage-subtitle" }),
       );
+      if (usage.planType) {
+        const planText =
+          usage.planType.charAt(0).toUpperCase() + usage.planType.slice(1);
+        accountDetails.add_child(
+          new St.Label({
+            text: planText,
+            style_class: "codexbar-usage-subtitle",
+            x_align: Clutter.ActorAlign.END,
+            x_expand: true,
+          }),
+        );
+      }
+      accountBox.add_child(accountDetails);
 
       if (usage.updatedAt) {
         let date = new Date(usage.updatedAt);
@@ -828,17 +845,27 @@ export default class CodexBarExtension extends Extension {
     const discoveredLabels = activeData.labels || [];
     let hasTiers = false;
 
-    tiers.forEach((tier, tierIdx) => {
-      if (usage[tier] && usage[tier].usedPercent !== undefined) {
-        hasTiers = true;
-        let tierData = usage[tier];
+    const usageEntries = tiers.map((tier, tierIdx) => ({
+      data: usage[tier],
+      showPace: true,
+      title:
+        discoveredLabels[tierIdx] ||
+        tier.charAt(0).toUpperCase() + tier.slice(1),
+    }));
+    usageEntries.push({
+      data: usage.codeReview,
+      showPace: false,
+      title: _("Code review"),
+    });
 
-        let tierTitle =
-          discoveredLabels[tierIdx] ||
-          tier.charAt(0).toUpperCase() + tier.slice(1);
+    usageEntries.forEach((entry) => {
+      if (entry.data && entry.data.usedPercent !== undefined) {
+        hasTiers = true;
+        let tierData = entry.data;
+
         this._contentBox.add_child(
           new St.Label({
-            text: tierTitle,
+            text: entry.title,
             style_class: "codexbar-usage-title",
           }),
         );
@@ -893,6 +920,35 @@ export default class CodexBarExtension extends Extension {
 
         this._contentBox.add_child(statsBox);
 
+        if (entry.showPace && tierData.windowSeconds >= 7 * 24 * 3600) {
+          const pace = calculateUsagePace(tierData);
+          if (pace) {
+            const roundedReserve = Math.round(pace.reservePercent);
+            const paceBox = new St.BoxLayout({ vertical: false, x_expand: true });
+            paceBox.add_child(
+              new St.Label({
+                text:
+                  roundedReserve >= 0
+                    ? _("%d%% in reserve").format(roundedReserve)
+                    : _("%d%% over pace").format(Math.abs(roundedReserve)),
+                style_class: "codexbar-usage-subtitle",
+              }),
+            );
+            paceBox.add_child(
+              new St.Label({
+                text:
+                  roundedReserve >= 0
+                    ? _("Lasts until reset")
+                    : _("May run out before reset"),
+                style_class: "codexbar-usage-subtitle",
+                x_align: Clutter.ActorAlign.END,
+                x_expand: true,
+              }),
+            );
+            this._contentBox.add_child(paceBox);
+          }
+        }
+
         let sep = new St.Widget({
           style:
             "height: 1px; background-color: rgba(255,255,255,0.05); margin-bottom: 10px; margin-top: 5px;",
@@ -900,6 +956,31 @@ export default class CodexBarExtension extends Extension {
         this._contentBox.add_child(sep);
       }
     });
+
+    if (usage.rateLimitResetCredits?.availableCount !== undefined) {
+      const creditCount = usage.rateLimitResetCredits.availableCount;
+      const creditsBox = new St.BoxLayout({
+        vertical: true,
+        style_class: "codexbar-reset-credits",
+        x_expand: true,
+      });
+      creditsBox.add_child(
+        new St.Label({
+          text: _("Limit reset credits"),
+          style_class: "codexbar-usage-title",
+        }),
+      );
+      creditsBox.add_child(
+        new St.Label({
+          text:
+            creditCount === 1
+              ? _("1 available")
+              : _("%d available").format(creditCount),
+          style_class: "codexbar-usage-subtitle",
+        }),
+      );
+      this._contentBox.add_child(creditsBox);
+    }
 
     if (!hasTiers && usage.providerCost) {
       let costBox = new St.BoxLayout({

--- a/prefs.js
+++ b/prefs.js
@@ -434,6 +434,21 @@ const CodexBarPrefsPage = GObject.registerClass(
       );
       group.add(showLogosRow);
 
+      const showPacingInfoRow = new Adw.SwitchRow({
+        title: _("Show Usage Pacing"),
+        subtitle: _(
+          "Display weekly pacing estimates (reserve or over pace) for large windows",
+        ),
+        active: this._settings.get_boolean("show-pacing-info"),
+      });
+      this._settings.bind(
+        "show-pacing-info",
+        showPacingInfoRow,
+        "active",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+      group.add(showPacingInfoRow);
+
       return group;
     }
 

--- a/schemas/org.gnome.shell.extensions.codexbar.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.codexbar.gschema.xml
@@ -26,6 +26,10 @@
       <default>true</default>
       <summary>Whether to show provider logos in the tabs</summary>
     </key>
+    <key name="show-pacing-info" type="b">
+      <default>true</default>
+      <summary>Whether to show weekly usage pacing details</summary>
+    </key>
     <key name="dev-custom-output-enabled" type="b">
       <default>false</default>
       <summary>Enable developer custom output simulation</summary>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -86,6 +86,12 @@
     border-radius: 3px;
 }
 
+.codexbar-reset-credits {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    padding-top: 12px;
+    margin-top: 2px;
+}
+
 .codexbar-footer {
     padding: 10px;
     border-top: 1px solid rgba(255, 255, 255, 0.1);

--- a/test_all_providers.js
+++ b/test_all_providers.js
@@ -1,4 +1,8 @@
-import { formatResetDescription, UsageApiClient } from "./usageApi.js";
+import {
+  calculateUsagePace,
+  formatResetDescription,
+  UsageApiClient,
+} from "./usageApi.js";
 
 const client = new UsageApiClient();
 
@@ -259,6 +263,18 @@ console.log(
   "✓ Weekly reset dates are shown only when the reset is on another day",
 );
 
+const screenshotPace = calculateUsagePace({
+  usedPercent: 2,
+  windowSeconds: 7 * 24 * 3600,
+  resetAfterSeconds: (6 * 24 + 14) * 3600,
+});
+if (!screenshotPace || Math.round(screenshotPace.reservePercent) !== 4) {
+  throw new Error(
+    `Expected the screenshot's weekly window to have 4% in reserve, got ${screenshotPace?.reservePercent}`,
+  );
+}
+console.log("✓ Weekly usage pace calculates reserve from the reset window");
+
 // Codex + Spark: canonical windows stay in primary/secondary, Spark windows
 // fill tertiary/quaternary, and labels cover all four tiers in order.
 const codexSpark = client.normalizeSummary(codexSparkUsage, false);
@@ -291,6 +307,40 @@ if (JSON.stringify(codexSpark.labels) !== JSON.stringify(expectedSparkLabels)) {
 console.log(
   "✓ Codex extraRateWindows are appended after canonical windows with labels",
 );
+
+// Codex dashboard metadata that is available from the Linux usage endpoint.
+const codexDashboardPayload = {
+  email: "user@example.com",
+  plan_type: "plus",
+  rate_limit: {
+    primary_window: {
+      used_percent: 10,
+      limit_window_seconds: 604800,
+      reset_after_seconds: 566279,
+    },
+  },
+  code_review_rate_limit: {
+    primary_window: {
+      used_percent: 2,
+      limit_window_seconds: 604800,
+      reset_after_seconds: 400000,
+    },
+  },
+  rate_limit_reset_credits: {
+    available_count: 2,
+  },
+};
+const normalizedDashboard = client.normalizeSummary(codexDashboardPayload);
+if (normalizedDashboard.usage.planType !== "plus") {
+  throw new Error("Expected Codex plan type to be preserved");
+}
+if (normalizedDashboard.usage.codeReview?.usedPercent !== 2) {
+  throw new Error("Expected Codex code review limit to be normalized");
+}
+if (normalizedDashboard.usage.rateLimitResetCredits?.availableCount !== 2) {
+  throw new Error("Expected Codex reset-credit count to be normalized");
+}
+console.log("\u2713 Codex plan, code review, and reset credits normalize correctly");
 
 // Test OpenCode Go Zen providerCost normalization
 const zenPayload = {

--- a/usageApi.js
+++ b/usageApi.js
@@ -144,6 +144,33 @@ export const formatResetDescription = (seconds, windowSeconds, now = new Date())
     return `Resets at ${resetStr} (in ${hours}h)`;
 };
 
+export const calculateUsagePace = (usageWindow) => {
+    const usedPercent = Number(usageWindow?.usedPercent);
+    const windowSeconds = Number(usageWindow?.windowSeconds);
+    const resetAfterSeconds = Number(usageWindow?.resetAfterSeconds);
+    if (
+        !Number.isFinite(usedPercent) ||
+        !Number.isFinite(windowSeconds) ||
+        !Number.isFinite(resetAfterSeconds) ||
+        windowSeconds <= 0 ||
+        resetAfterSeconds <= 0
+    ) {
+        return null;
+    }
+
+    const elapsedSeconds = Math.min(
+        windowSeconds,
+        Math.max(0, windowSeconds - resetAfterSeconds)
+    );
+    if (elapsedSeconds <= 0) return null;
+
+    const expectedUsedPercent = elapsedSeconds / windowSeconds * 100;
+    return {
+        expectedUsedPercent,
+        reservePercent: expectedUsedPercent - usedPercent,
+    };
+};
+
 export class UsageApiClient {
     constructor(extensionPath = null) {
         this._session = new Soup.Session({
@@ -206,8 +233,32 @@ export class UsageApiClient {
                     win.reset_after_seconds,
                     win.window_seconds
                 ) || obj?.resetDescription || '',
-                windowSeconds: win.window_seconds
+                windowSeconds: win.window_seconds,
+                resetAfterSeconds: win.reset_after_seconds
             };
+        };
+
+        const codeReviewRateLimit =
+            payload?.code_review_rate_limit ?? payload?.codeReviewRateLimit;
+        const codeReviewWindow = codeReviewRateLimit && (
+            codeReviewRateLimit.primary_window ??
+            codeReviewRateLimit.primary ??
+            codeReviewRateLimit
+        );
+        const resetCredits =
+            payload?.rate_limit_reset_credits ?? payload?.rateLimitResetCredits;
+        const availableResetCredits = Number(
+            resetCredits?.available_count ?? resetCredits?.availableCount
+        );
+        const codexDetails = {
+            planType: payload?.plan_type ?? payload?.planType ?? '',
+            codeReview: mapSingle(codeReviewWindow),
+            rateLimitResetCredits: Number.isFinite(availableResetCredits)
+                ? {
+                    ...resetCredits,
+                    availableCount: availableResetCredits,
+                }
+                : null,
         };
 
         const extraWindows = payload?.extraRateWindows || payload?.usage?.extraRateWindows;
@@ -238,6 +289,7 @@ export class UsageApiClient {
                     accountEmail: payload?.accountEmail || payload?.email || payload?.identity?.accountEmail || 'Antigravity User',
                     loginMethod: payload?.loginMethod || payload?.identity?.loginMethod || '',
                     updatedAt: payload?.updatedAt || new Date().toISOString(),
+                    ...codexDetails,
                     ...mappedTiers
                 }
             };
@@ -284,6 +336,7 @@ export class UsageApiClient {
                     ...payload,
                     accountEmail: payload?.accountEmail || payload?.email || 'API User',
                     updatedAt: payload?.updatedAt || new Date().toISOString(),
+                    ...codexDetails,
                     ...mappedTiers,
                 }
             };
@@ -299,7 +352,8 @@ export class UsageApiClient {
                 w.reset_after_seconds,
                 w.window_seconds
             ) || '',
-            windowSeconds: w.window_seconds
+            windowSeconds: w.window_seconds,
+            resetAfterSeconds: w.reset_after_seconds
         } : null;
 
         return {
@@ -307,6 +361,7 @@ export class UsageApiClient {
                 ...payload,
                 accountEmail: payload?.accountEmail || payload?.email || 'API User',
                 updatedAt: payload?.updatedAt || new Date().toISOString(),
+                ...codexDetails,
                 primary: mapWindow(sorted[0], payload?.primary) || payload?.primary || null,
                 secondary: mapWindow(sorted[1], payload?.secondary) || payload?.secondary || null,
                 tertiary: mapWindow(sorted[2], payload?.tertiary) || payload?.tertiary || null,


### PR DESCRIPTION
## Summary

- show the Codex account plan and available limit-reset credits
- calculate and display weekly usage pace from the existing quota window
- render Code review usage when the Linux API supplies it
- add regression coverage for the new normalization and pace calculation

## Why

The Linux usage endpoint already exposes the plan and reset-credit count, and its weekly window contains enough timing data to calculate whether usage is in reserve or over pace. The extension previously discarded those fields and only rendered quota bars.

Code review remains conditional because the Linux endpoint can return that field as `null`; no macOS-only web source or WebView dependency is introduced.

## User impact

Codex users get a more complete usage card with English labels while retaining the existing Linux authentication and fetch path.

## Validation

- `gjs -m test_all_providers.js`
- `node --check extension.js`
- `node --check usageApi.js`
- `git diff --check`
