### PR TITLE
feat(usageApi): Support Codex Spark usage tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A GNOME Shell extension to monitor AI provider usage metrics directly from the s
 ## Features
 
 - Real-time monitoring of AI provider usage (Gemini, OpenAI, etc).
-- Support for multiple usage tiers
+- Support for standard Codex and Codex Spark 5-hour/weekly usage tiers
 - Toggle between Remaining Quota and Used Quota display modes.
 - Automatic background refreshes with configurable intervals.
 - Visual warnings (color changes) when reaching quota limits.

--- a/test_all_providers.js
+++ b/test_all_providers.js
@@ -306,6 +306,73 @@ console.log(
   "✓ Codex extraRateWindows are appended after canonical windows with labels",
 );
 
+// The direct ChatGPT endpoint exposes Spark as additional_rate_limits rather
+// than the CLI's normalized extraRateWindows shape.
+const directCodexSpark = client.normalizeSummary({
+  email: "spark@example.com",
+  plan_type: "prolite",
+  rate_limit: {
+    primary_window: {
+      used_percent: 2,
+      limit_window_seconds: 18000,
+      reset_after_seconds: 14400,
+    },
+    secondary_window: {
+      used_percent: 4,
+      limit_window_seconds: 604800,
+      reset_after_seconds: 518400,
+    },
+  },
+  additional_rate_limits: [
+    {
+      limit_name: "GPT-5.3-Codex-Spark",
+      metered_feature: "codex_bengalfox",
+      rate_limit: {
+        primary_window: {
+          used_percent: 0,
+          limit_window_seconds: 18000,
+          reset_after_seconds: 17640,
+        },
+        secondary_window: {
+          used_percent: 0,
+          limit_window_seconds: 604800,
+          reset_after_seconds: 572400,
+        },
+      },
+    },
+  ],
+});
+
+const directSparkExpectations = [
+  ["primary", 2],
+  ["secondary", 4],
+  ["tertiary", 0],
+  ["quaternary", 0],
+];
+directSparkExpectations.forEach(([tier, expected]) => {
+  const actual = directCodexSpark.usage[tier]?.usedPercent;
+  if (actual !== expected) {
+    throw new Error(
+      `Direct Codex Spark: expected ${tier} at ${expected}% used, got ${actual}`,
+    );
+  }
+});
+const expectedDirectSparkLabels = [
+  "5-Hour Window",
+  "Weekly Window",
+  "Codex Spark 5-hour",
+  "Codex Spark Weekly",
+];
+if (
+  JSON.stringify(directCodexSpark.labels) !==
+  JSON.stringify(expectedDirectSparkLabels)
+) {
+  throw new Error(
+    `Direct Codex Spark: expected labels ${JSON.stringify(expectedDirectSparkLabels)}, got ${JSON.stringify(directCodexSpark.labels)}`,
+  );
+}
+console.log("✓ Direct Codex additional_rate_limits render as Spark tiers");
+
 // Codex dashboard metadata that is available from the Linux usage endpoint.
 const codexDashboardPayload = {
   email: "user@example.com",

--- a/usageApi.js
+++ b/usageApi.js
@@ -43,11 +43,21 @@ const normalizePercentValue = (rawPercent, mode = 'used') => {
 const makeWindow = (obj) => {
     if (!obj || typeof obj !== 'object') return null;
 
-    let window_seconds = obj.limit_window_seconds || obj.window_seconds || obj.duration_seconds || 0;
+    let window_seconds =
+        obj.limit_window_seconds ||
+        obj.limitWindowSeconds ||
+        obj.window_seconds ||
+        obj.windowSeconds ||
+        obj.duration_seconds ||
+        0;
     if (!window_seconds && obj.windowMinutes) {
         window_seconds = obj.windowMinutes * 60;
     }
-    let reset_after_seconds = obj.reset_after_seconds || obj.reset_after || 0;
+    let reset_after_seconds =
+        obj.reset_after_seconds ||
+        obj.resetAfterSeconds ||
+        obj.reset_after ||
+        0;
     if (!reset_after_seconds && obj.resetsAt) {
         const diffMs = new Date(obj.resetsAt).getTime() - Date.now();
         reset_after_seconds = Math.max(0, Math.round(diffMs / 1000));
@@ -313,7 +323,13 @@ export class UsageApiClient {
         // then fill any remaining tier slots with extraRateWindows (e.g. Codex Spark)
         // Si ya tiene niveles estructurados, normalizarlos manteniendo el orden,
         // y rellenar los niveles restantes con extraRateWindows (ej. Codex Spark)
-        if (payload.primary || payload.secondary || payload.tertiary) {
+        const canonicalRateLimit = payload?.rate_limit || payload?.rateLimit;
+        if (
+            payload.primary ||
+            payload.secondary ||
+            payload.tertiary ||
+            canonicalRateLimit
+        ) {
             const labelForWindow = (win) => {
                 if (!win || !win.windowSeconds) return 'Usage Window';
                 const hours = Math.round(win.windowSeconds / 3600);
@@ -327,13 +343,47 @@ export class UsageApiClient {
             const queue = [];
             const tierKeys = ['primary', 'secondary', 'tertiary', 'quaternary'];
             tierKeys.forEach((key) => {
-                const win = mapSingle(payload[key]);
+                const snakeCaseKey = `${key}_window`;
+                const camelCaseKey = `${key}Window`;
+                const win = mapSingle(
+                    payload[key] ||
+                    canonicalRateLimit?.[snakeCaseKey] ||
+                    canonicalRateLimit?.[camelCaseKey]
+                );
                 if (win) queue.push({ win, label: labelForWindow(win) });
             });
             if (Array.isArray(extraWindows)) {
                 extraWindows.forEach((item) => {
                     const win = mapSingle(item?.window);
                     if (win) queue.push({ win, label: item?.title || labelForWindow(win) });
+                });
+            }
+
+            const additionalRateLimits =
+                payload?.additional_rate_limits || payload?.additionalRateLimits;
+            if (Array.isArray(additionalRateLimits)) {
+                additionalRateLimits.forEach((item) => {
+                    const rateLimit = item?.rate_limit || item?.rateLimit;
+                    const limitName = item?.limit_name || item?.limitName || '';
+                    const displayName = /codex.*spark/i.test(limitName)
+                        ? 'Codex Spark'
+                        : limitName;
+
+                    ['primary', 'secondary'].forEach((key) => {
+                        const rawWindow =
+                            rateLimit?.[`${key}_window`] || rateLimit?.[`${key}Window`];
+                        const win = mapSingle(rawWindow);
+                        if (!win) return;
+
+                        const windowLabel = labelForWindow(win);
+                        let suffix = windowLabel;
+                        if (windowLabel === 'Weekly Window') suffix = 'Weekly';
+                        else suffix = windowLabel.replace('Hour Window', 'hour');
+                        queue.push({
+                            win,
+                            label: displayName ? `${displayName} ${suffix}` : windowLabel,
+                        });
+                    });
                 });
             }
 


### PR DESCRIPTION
Add normalization for direct ChatGPT rate-limit payloads and cover
Codex Spark window labels with tests.
